### PR TITLE
🐛 Make setup.py actually install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open(os.path.join(repository_dir, 'requirements.txt')) as fh:
 setup(
     author="Graham Hammond",
     author_email="support@mbed.com",
-    classifiers=(
+    classifiers=[
         'Development Status :: 3 - Alpha'
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
@@ -35,7 +35,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Topic :: Software Development :: Build Tools'
         'Topic :: Software Development :: Embedded Systems',
-    ),
+    ],
     description="Mbed Tools: Target information for building Mbed OS",
     keywords="Arm Mbed OS MbedOS build target platform board module",
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,6 @@ setup(
     name=PACKAGE_NAME,
     packages=[SOURCE_DIR],
     python_requires='>=3.6,<4',
-    url="https://github.com/ARMmbed/%s" % PACKAGE_NAME,
+    url=f"https://github.com/ARMmbed/{PACKAGE_NAME}",
     version=__version__,
 )

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ with open(os.path.join(repository_dir, 'requirements.txt')) as fh:
     requirements = fh.readlines()
 
 setup(
-    author="Graham Hammond",
-    author_email="support@mbed.com",
+    author='Graham Hammond',
+    author_email='support@mbed.com',
     classifiers=[
         'Development Status :: 3 - Alpha'
         'Intended Audience :: Developers',
@@ -35,8 +35,8 @@ setup(
         'Topic :: Software Development :: Build Tools'
         'Topic :: Software Development :: Embedded Systems',
     ],
-    description="Mbed Tools: Target information for building Mbed OS",
-    keywords="Arm Mbed OS MbedOS build target platform board module",
+    description='Mbed Tools: Target information for building Mbed OS',
+    keywords='Arm Mbed OS MbedOS build target platform board module',
     include_package_data=True,
     install_requires=requirements,
     license='Apache 2.0',
@@ -45,6 +45,6 @@ setup(
     name=PACKAGE_NAME,
     packages=[SOURCE_DIR],
     python_requires='>=3.6,<4',
-    url=f"https://github.com/ARMmbed/{PACKAGE_NAME}",
+    url=f'https://github.com/ARMmbed/{PACKAGE_NAME}',
     version=__version__,
 )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 """Package definition for PyPI."""
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 PACKAGE_NAME = 'mbed-targets'
@@ -44,8 +43,7 @@ setup(
     long_description_content_type='text/markdown',
     long_description=long_description,
     name=PACKAGE_NAME,
-    package_dir={'': SOURCE_DIR},
-    packages=find_packages(SOURCE_DIR),
+    packages=[SOURCE_DIR],
     python_requires='>=3.6,<4',
     url="https://github.com/ARMmbed/%s" % PACKAGE_NAME,
     version=__version__,


### PR DESCRIPTION
### Description

While exploring cli layout and cross-package dependencies I discovered that `mbed-targets` doesn't install correctly. At the moment `find_packages()` is called incorrectly with `"mbed_targets"` as argument, resulting in `_internal` being installed as package instead (`find_packages("mbed_targets") == ["_internal"]`):

```
❯ python setup.py install
...
❯ pip list
Package            Version
------------------ ----------
...
mbed-targets       0.1.0
...
```

```
❯ cd outside_of_project_directory # <- this is important, as otherwise mbed_targets is available as local package
❯ python
Python 3.7.3 (default, Oct 11 2019, 19:39:43)
[Clang 11.0.0 (clang-1100.0.33.12)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import mbed_targets
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'mbed_targets'
>>> import _internal
>>> _internal
<module '_internal' from '/Users/barmuc01/.local/share/virtualenvs/mbed-targets-39gjAcyB/lib/python3.7/site-packages/mbed_targets-0.1.0-py3.7.egg/_internal/__init__.py'>
```

This PR fixes the above issue, by swapping `find_packages()` with a single element list, which is preferred for simple projects.

I'm also using it as an opportunity to improve formatting of `setup.py` and fixing misc warnings.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [x]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
